### PR TITLE
Improve 'parse' function

### DIFF
--- a/CIRS_lib/CIRS_lib/file.vb
+++ b/CIRS_lib/CIRS_lib/file.vb
@@ -16,11 +16,11 @@
         End Try
     End Sub
 
-    Public Function parse(input As String, find As String, stopAt As String)
-        Dim x As Integer = (input.IndexOf(find) + Len(find)) 'Parse a string using a character/string to stop at
+    Public Function textBetweenStrings(input As String, startString As String, endString As String) As String 'Find a string within a string using start and stop strings/characters
+        Dim x As Integer = (input.IndexOf(startString) + Len(startString))
         Dim output As String = ""
         Try
-            While input(x) <> stopAt
+            While input(x) <> endString(0)
                 output += input(x)
                 x += 1
             End While


### PR DESCRIPTION
- Rename to more correct function and parameter names.
- Fixed to allow end strings with length > 1.
- Set function to an explicit type (String).
- Improved comment.